### PR TITLE
Adding type safety to validation.

### DIFF
--- a/src/Forms.elm
+++ b/src/Forms.elm
@@ -2,25 +2,40 @@ module Forms
     exposing
         ( FieldValidator
         , Form
-        , ValidationError (..)
+        , DependencyValidator
+        , DependencyError(..)
+        , FormElement
+        , ValidationError(..)
         , errorList
         , errorString
         , formValue
         , initForm
+        , initFormElement
         , updateFormInput
+        , validateExistence
+        , validateField
         , validateGreaterThan
         , validateIsOneOf
-        , validateMinLength
-        , validateMaxLength
         , validateLessThan
-        , validateExistence
-        , validateNumericality
+        , validateMaxLength
+        , validateMinLength
         , validateNumericRange
+        , validateNumericality
+        , validatePob
         , validateRegex
         , validateStatus
+        , updateFormInputs
+        , stringToInt
+        , stringToFloat
+          -- dependency validator
+        , haveSameValue
         )
 
-{-| # Forms
+{-|
+
+
+# Forms
+
 This library performs form validation for HTML forms. A user can define
 a list of form elements and define validations for each element. Each time the
 formis updated, validations are automatically run and validation results are updated
@@ -29,19 +44,27 @@ for each form element as well as the overall form.
 API calls can be used to retrieve validation information that can be used to
 display validation errors on the form itself.
 
+
 # Definition
 
+
 # Types
+
 @docs FieldValidator, Form, ValidationError
 
+
 # Helper Functions
+
 @docs errorList, errorString, formValue, updateFormInput, validateStatus
 
+
 # Form Initializer
+
 @docs initForm
 
 
 # Primitive Validators
+
 @docs validateGreaterThan, validateIsOneOf, validateMinLength
 @docs validateMaxLength, validateLessThan, validateExistence
 @docs validateNumericality, validateNumericRange, validateRegex
@@ -53,10 +76,10 @@ import Regex
 
 
 {-| A validation result is simply a Maybe String.
-    Nothing indicates no error. Otherwise it's Just "error message"
+Nothing indicates no error. Otherwise it's Just "error message"
 -}
-type ValidationError =
-      NotGreaterThan Int
+type ValidationError
+    = NotGreaterThan Int
     | DoesNotExist
     | MinLength Int
     | MaxLength Int
@@ -65,23 +88,33 @@ type ValidationError =
     | NotInNumericRange Int Int
     | NotLessThan Int
     | NotOneOf (List String)
+    | InvalidPob
     | CustomError String
 
 
+type DependencyError
+    = DependencyError String String ValidationError
+
+
 {-| A field validator is a function that takes a string to be validated and
-    returns a ValidationError (Maybe String)
+returns a ValidationError (Maybe String)
 -}
 type alias FieldValidator =
     String -> Maybe ValidationError
 
 
+type alias DependencyValidator =
+    List ( String, FormElement ) -> Maybe DependencyError
+
+
 {-| A form is a set of form elements and a boolean indicating the validate
-    status. Details of the FormElements type are not exposed to the user.
-    Instead an API is provided so those details can be fluid.
+status. Details of the FormElements type are not exposed to the user.
+Instead an API is provided so those details can be fluid.
 -}
 type alias Form =
     { elements : FormElements
     , validateStatus : Bool
+    , dependencyValidators : List DependencyValidator
     }
 
 
@@ -92,6 +125,7 @@ type alias FormElements =
 type alias FormElement =
     { input : String
     , errors : List ValidationError
+    , dependencyErrors : List DependencyError
     , validator : List FieldValidator
     }
 
@@ -100,12 +134,88 @@ initFormElement : ( String, List FieldValidator ) -> FormElement
 initFormElement field =
     { input = ""
     , errors = validateField "" (Tuple.second field)
+    , dependencyErrors = [] -- @TODO do we really want to initialize this as empty?
     , validator = Tuple.second field
     }
 
 
+
+--changeFormInputByKeysIfEmpty : Form -> List ( String, String ) -> Form
+--changeFormInputByKeysIfEmpty form list =
+--    let
+--        a =
+--            List.map
+--                (\( k, v ) ->
+--                    (if (formValue form k == "") then
+--                        ( k, changeFormElementInput form ( k, v ) )
+--                     else
+--                        ( k, changeFormElementInput form ( k, formValue form k ) )
+--                    )
+--                )
+--                list
+--        b =
+--            List.concat [ Dict.toList form.elements, a ]
+--    in
+--        { elements = Dict.fromList b
+--        , validateStatus = form.validateStatus
+--        }
+--changeFormElementInput : Form -> ( String, String ) -> FormElement
+--changeFormElementInput form ( key, newValue ) =
+--    let
+--        a =
+--            List.filter (\( k, v ) -> k == key) (Dict.toList form.elements)
+--        b =
+--            List.head a
+--    in
+--        case b of
+--            Nothing ->
+--                { input = ""
+--                , errors = []
+--                , validator = []
+--                }
+--            Just b ->
+--                { input = newValue
+--                , errors = (Tuple.second b).errors
+--                , validator = (Tuple.second b).validator
+--                }
+
+
+updateFormInputs : Form -> List ( String, String ) -> Form
+updateFormInputs f elems =
+    List.foldl
+        (\( key, value ) form ->
+            if (formValue f key == "") then
+                updateFormInput form key value
+            else
+                f
+        )
+        f
+        elems
+
+
+
+--changeShippingInfoForm2 : List ( String, FormElement ) -> ( String, String ) -> ( String, FormElement )
+--changeShippingInfoForm2 elems ( key, value ) =
+--    let
+--        a =
+--            List.map
+--                (\( k, v ) ->
+--                    if key == k then
+--                        ( k, value )
+--                    else
+--                        ( k, v )
+--                )
+--                elems
+--    in
+--        case List.head (List.filter (\( c, d ) -> c == key) a) of
+--            Nothing ->
+--                ( key, value )
+--            Just a ->
+--                a
+
+
 {-| Initializes a form.Accepts a list of (name, validator) tuples
-    and returns a Form.
+and returns a Form.
 -}
 initForm : List ( String, List FieldValidator ) -> Form
 initForm fields =
@@ -116,46 +226,57 @@ initForm fields =
                 Dict.empty
                 fields
     in
-        Form elements False
+        Form elements False []
 
 
 {-| Given a Form, a field name and a feild value and returns
-    a new form containing the update. This is genrally called
-    from the application's update function.
+a new form containing the update. This is genrally called
+from the application's update function.
 -}
 updateFormInput : Form -> String -> String -> Form
 updateFormInput form name value =
     let
         formElement =
             Dict.get name form.elements
-    in
-        case formElement of
-            Just element ->
-                let
-                    newFormElement =
-                        { element
-                            | input = value
-                            , errors = validateField value element.validator
+
+        newForm =
+            case formElement of
+                Just element ->
+                    let
+                        newFormElement =
+                            { element
+                                | input = value
+                                , errors = validateField value element.validator
+                                , dependencyErrors = []
+                            }
+
+                        tmpFormElements =
+                            Dict.insert name
+                                newFormElement
+                                form.elements
+
+                        dependencyErrors =
+                            validateDependencies (Dict.toList tmpFormElements) form.dependencyValidators
+
+                        newFormElements =
+                            addDependencyErrorsToErrorList dependencyErrors (removeDependencyErrors tmpFormElements)
+                    in
+                        { form
+                            | elements = newFormElements
+                            , validateStatus =
+                                validateForm { form | elements = newFormElements }
                         }
 
-                    newFormElements =
-                        Dict.insert name
-                            newFormElement
-                            form.elements
-                in
-                    { form
-                        | elements = newFormElements
-                        , validateStatus =
-                            validateForm { form | elements = newFormElements }
-                    }
-
-            Nothing ->
-                form
+                Nothing ->
+                    form
+    in
+        newForm
 
 
 {-| Returns a formatted string representing all current validation errors.
 
     ErrorSring form "user" == "must be present, must be 10 characters or fewer"
+
 -}
 errorString : Form -> String -> String
 errorString form name =
@@ -165,10 +286,26 @@ errorString form name =
 {-| Returns raw list of all current validation errors."
 
     ErrorList form "user" == [ Just "must be present", Just "must be 10 characters or fewer" ]
+
 -}
 errorList : Form -> String -> List ValidationError
 errorList form name =
     lookupErrorValue form name
+
+
+catMaybes : List (Maybe a) -> List a
+catMaybes xs =
+    List.foldl
+        (\mElem newList ->
+            case mElem of
+                Nothing ->
+                    newList
+
+                Just elem ->
+                    elem :: newList
+        )
+        []
+        xs
 
 
 lookupErrorValue : Form -> String -> List ValidationError
@@ -179,38 +316,75 @@ lookupErrorValue form name =
     in
         case lookupValue of
             Just value ->
-                value.errors
+                List.concat
+                    [ value.errors
+                    , catMaybes
+                        (List.map
+                            (\(DependencyError from to validationError) ->
+                                if name == from || name == to then
+                                    Just validationError
+                                else
+                                    Nothing
+                            )
+                            value.dependencyErrors
+                        )
+                    ]
 
             Nothing ->
                 []
 
+
 validationErrorToString : ValidationError -> String
 validationErrorToString err =
     case err of
-        NotGreaterThan n -> "must be < " ++ toString n
-        DoesNotExist -> "must be present"
-        MinLength n -> "must be at least " ++ toString n ++ " characters"
-        MaxLength n -> "must be " ++ toString n ++ " characters of fewer"
-        NotRegex s -> "invalid string format"
-        NotNumeric -> "must be numeric"
-        NotInNumericRange from to -> "must be between " ++ toString from ++ " and " ++ toString to
-        NotLessThan n -> "must be > " ++ toString n
-        NotOneOf matches -> "must match one of (" ++ String.join ", " matches ++ ")"
-        CustomError err -> err
+        NotGreaterThan n ->
+            "must be < " ++ toString n
+
+        DoesNotExist ->
+            "must be present"
+
+        MinLength n ->
+            "must be at least " ++ toString n ++ " characters"
+
+        MaxLength n ->
+            "must be " ++ toString n ++ " characters of fewer"
+
+        NotRegex s ->
+            "invalid string format"
+
+        NotNumeric ->
+            "must be numeric"
+
+        NotInNumericRange from to ->
+            "must be between " ++ toString from ++ " and " ++ toString to
+
+        NotLessThan n ->
+            "must be > " ++ toString n
+
+        NotOneOf matches ->
+            "must match one of (" ++ String.join ", " matches ++ ")"
+
+        CustomError err ->
+            err
+
+        InvalidPob ->
+            "Not valid pob"
+
 
 errorsToString : List ValidationError -> String
 errorsToString errors =
     let
-        errorList = List.map validationErrorToString errors
+        errorList =
+            List.map validationErrorToString errors
     in
         if List.length errorList == 0 then
             "no errors"
         else
             String.join ", " errorList
 
-{-| Returns the current value of any form field.
-    Returns Nothing if an invalid form name is given.
 
+{-| Returns the current value of any form field.
+Returns Nothing if an invalid form name is given.
 -}
 formValue : Form -> String -> String
 formValue form name =
@@ -247,16 +421,64 @@ validateForm form =
     let
         errorElements =
             List.concatMap
-                (\elem -> validateSingle (Tuple.second elem))
+                (\elem -> (Tuple.second elem).errors)
+                (Dict.toList form.elements)
+
+        dependencyErrors =
+            List.concatMap
+                (\elem -> (Tuple.second elem).dependencyErrors)
                 (Dict.toList form.elements)
     in
-        (errorElements |> List.length) == 0
+        (errorElements |> List.length) == 0 && (dependencyErrors |> List.length) == 0
+
+
+stringToInt str =
+    String.toInt str |> Result.toMaybe |> Maybe.withDefault 100
+
+
+stringToFloat str =
+    String.toFloat str |> Result.toMaybe |> Maybe.withDefault 100
 
 
 validateField : String -> List (String -> Maybe ValidationError) -> List ValidationError
 validateField data validations =
     List.map (\e -> e data) validations
         |> List.filterMap identity
+
+
+validateDependencies : List ( String, FormElement ) -> List DependencyValidator -> List DependencyError
+validateDependencies allFormElems validations =
+    List.map (\e -> e allFormElems) validations
+        |> List.filterMap identity
+
+
+removeDependencyErrors : Dict.Dict String FormElement -> Dict.Dict String FormElement
+removeDependencyErrors =
+    Dict.map (\key v -> { v | dependencyErrors = [] })
+
+
+addDependencyErrorsToErrorList : List DependencyError -> Dict.Dict String FormElement -> Dict.Dict String FormElement
+addDependencyErrorsToErrorList errors elems =
+    List.foldl
+        (\(DependencyError from to validationError) elems_ ->
+            Dict.update to
+                (\maybeE ->
+                    case maybeE of
+                        Nothing ->
+                            Nothing
+
+                        Just e ->
+                            Just
+                                { e
+                                    | dependencyErrors =
+                                        (DependencyError from to validationError)
+                                            :: e.dependencyErrors
+                                }
+                )
+                elems_
+        )
+        elems
+        errors
 
 
 
@@ -267,6 +489,7 @@ validateField data validations =
 
     validateExistence "" == Just "must be present"
     validateExistence "valid" == Nothing
+
 -}
 validateExistence : String -> Maybe ValidationError
 validateExistence string =
@@ -280,6 +503,7 @@ validateExistence string =
 
     validateMinLength 2 "123" == Nothing
     validateMinLength 4 "123" == Just "must be at least 4 characters"
+
 -}
 validateMinLength : Int -> String -> Maybe ValidationError
 validateMinLength minLength string =
@@ -293,6 +517,7 @@ validateMinLength minLength string =
 
     validateMaxLength 4 "123" == Nothing
     validateMaxLength 2 "123" == Just "must be at least 2 characters or fewer"
+
 -}
 validateMaxLength : Int -> String -> Maybe ValidationError
 validateMaxLength maxLength string =
@@ -328,6 +553,16 @@ validateNumericality string =
                 Just NotNumeric
 
 
+validatePob : String -> Maybe ValidationError
+validatePob string =
+    case validateNumericRange 0 999999 string of
+        Nothing ->
+            Nothing
+
+        Just err ->
+            Just InvalidPob
+
+
 {-| iValidates that an integer field is within a specified numeric range.
 -}
 validateNumericRange : Int -> Int -> String -> Maybe ValidationError
@@ -355,6 +590,7 @@ supplied
     validateLessThan 100 "95" == Nothing
     validateLessThan 100 "105" == Just "must be < 100"
     validateLessThan 100 "bad" == Just "must be < 100"
+
 -}
 validateLessThan : Int -> String -> Maybe ValidationError
 validateLessThan num string =
@@ -379,6 +615,7 @@ supplied
     validateGreaterThan 100 "105" == Nothing
     validateGreaterThan 100 "95" == Just "must be > 100"
     validateGreaterThan 100 "bad" == Just "must be > 100"
+
 -}
 validateGreaterThan : Int -> String -> Maybe ValidationError
 validateGreaterThan num string =
@@ -401,10 +638,43 @@ validateGreaterThan num string =
 
     validateIsOneOf [ "cat", "bat", "rat" ] "bat" == Nothing
     validateIsOneOf [ "cat", "bat", "rat" ] "brat" == Just "must match one of (cat, bat, rat)"
+
 -}
 validateIsOneOf : List String -> String -> Maybe ValidationError
 validateIsOneOf matches string =
-    if (List.any (\e -> e == string) matches) then
+    if List.any (\e -> e == string) matches then
         Nothing
     else
         Just (NotOneOf matches)
+
+
+{-| Validates that two form fields have equal values
+-}
+haveSameValue : String -> String -> List ( String, FormElement ) -> Maybe DependencyError
+haveSameValue name sameAsName elems =
+    let
+        firstElem =
+            dGet elems name
+
+        secondElem =
+            dGet elems sameAsName
+    in
+        case firstElem of
+            Just ( _, elem1 ) ->
+                case secondElem of
+                    Just ( _, elem2 ) ->
+                        if elem1.input == elem2.input then
+                            Nothing
+                        else
+                            Just (DependencyError name sameAsName (CustomError "Lozinke moraju biti jednake"))
+
+                    Nothing ->
+                        Nothing
+
+            Nothing ->
+                Nothing
+
+
+dGet : List ( a, b ) -> a -> Maybe ( a, b )
+dGet l elem =
+    List.head (List.filter (\( k, _ ) -> k == elem) l)

--- a/src/Forms.elm
+++ b/src/Forms.elm
@@ -675,6 +675,36 @@ haveSameValue name sameAsName elems =
                 Nothing
 
 
+isCheckedThenValidate : String -> String -> List FieldValidator -> List ( String, FormElement ) -> Maybe DependencyError
+isCheckedThenValidate checkboxName inputName validators elems =
+    let
+        mCheckbox =
+            dGet elems checkboxName
+
+        mInput =
+            dGet elems inputName
+    in
+        case mCheckbox of
+            Just ( _, checkbox ) ->
+                case mInput of
+                    Just ( _, input ) ->
+                        if checkbox.input == "true" then
+                            case List.head (validateSingle { input | validator = validators }) of
+                                Nothing ->
+                                    Nothing
+
+                                Just e ->
+                                    Just (DependencyError checkboxName inputName e)
+                        else
+                            Nothing
+
+                    Nothing ->
+                        Nothing
+
+            Nothing ->
+                Nothing
+
+
 dGet : List ( a, b ) -> a -> Maybe ( a, b )
 dGet l elem =
     List.head (List.filter (\( k, _ ) -> k == elem) l)

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,9 +1,9 @@
 module Main exposing (..)
 
+import Forms
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
-import Forms
 
 
 main : Program Never Model Msg

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -1,8 +1,8 @@
 port module Main exposing (..)
 
-import Tests
-import Test.Runner.Node exposing (run)
 import Json.Encode exposing (Value)
+import Test.Runner.Node exposing (run)
+import Tests
 
 
 main : Test.Runner.Node.TestProgram

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,10 +1,10 @@
 module Tests exposing (..)
 
-import Test exposing (..)
-import Expect
-import String
 import Dict
+import Expect
 import Forms
+import String
+import Test exposing (..)
 
 
 formsTests : List Test


### PR DESCRIPTION
Problem with `ValidationError = Maybe String` is that amongs other
things it does not handle customization well; how can I provide my own
error messages if API describes validations errror as Maybe String?

This commit introduces this abstraction with type safety; defining a
data constructor for each possible validation error. Public API has not
changed and errorsList returns same thing as in previous versions.

A new function was introduced, validationErrorToString which serves as a
blueprint for custom error messages. User has to define their own
validationErrorToString message.

refs #1 